### PR TITLE
Policy 10 - Forbid Cog Creators from associating with QA review

### DIFF
--- a/policies/accepted/10.md
+++ b/policies/accepted/10.md
@@ -49,7 +49,7 @@ QA will enforce the following requirements on a Cog Creator application:
 - Repositories must be kept up to date with the latest version of Red within 3 months of its release.
 
 ### Removing Cog Creator Perks
-If a Cog Creator is found to be in gross negligence, malicious intent, or reckless abandonment of their repository, the org may remove the Cog Creator status from that individual. Cog creator status may also be removed if the org can no longer maintain a working relationship with the Cog Creator. A vote to remove the Cog Creator must be called under this policy. This vote will include all active org members and a simple majority in favor is required to remove the Cog Creator. A Cog Creator removed in this fashion loses all perks outlined in the Perks for Approved Cog Creators, including having their repository delisted from the approved listings.
+If a Cog Creator is found to be in gross negligence, malicious intent, or reckless abandonment of their repository, the org may remove the Cog Creator status from that individual. Cog Creator status may also be removed if the org can no longer maintain a working relationship with the Cog Creator. A vote to remove the Cog Creator must be called under this policy. This vote will include all active org members and a simple majority in favor is required to remove the Cog Creator. A Cog Creator removed in this fashion loses all perks outlined in the Perks for Approved Cog Creators, including having their repository delisted from the approved listings.
 
 If a repository is not maintained or kept up to date with the latest Red version for 3 months, QA may remove that repository from the approved listings, however all other Cog Creator perks will not be affected. The repository may be added back to the approved listings onced it is maintained properly.
 
@@ -61,3 +61,4 @@ Cog Creator Applications must be submitted to the "Applications" category of cog
 - The Cog Creator status for a repository can be transferred to another user if the Cog Creator requests it.
 - An approved Cog Creator can ask QA to add additional repositories they have created to the approved pool.
 - Hidden cogs will not be explicitly reviewed, however they are not allowed to contain malicious or ToS breaking code.
+- Since the org has the right to remove a Cog Creator at any point, and the org has no direct control over a Cog Creator's repo, Cog Creators can not provide association with the QA review process or services provided by the org. This includes stating that a cog or repository is "approved", or that the org has reviewed any particular code.


### PR DESCRIPTION
Amends policy 10 to add the following to the *Other Stipulations* section.
> Since the org has the right to remove a Cog Creator at any point, and the org has no direct control over a Cog Creator's repo, Cog Creators can not provide association with the QA review process or services provided by the org. This includes stating that a cog or repository is "approved", or that the org has reviewed any particular code.

Also fixes a lowercase c.