### PR TITLE
Updates to "Org forced removal" section in Policy 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,5 @@ The [definitions and clarifications](definitions.md) for terms used in these pol
 | [Policy 10](policies/active/0010.md) | *create* | *passed* | 8 | 0 | 0 | 0 | 8 | 11th of November 2020
 | [Policy 9](policies/active/0009.md) | *amend* | *passed* | 7 | 0 | 0 | 0 | 7 | 14th of April 2021
 | [Policy 10](policies/active/0010.md) | *amend* | *passed* | 7 | 0 | 0 | 0 | 7 | 14th of April 2021
-| [Policy 11](policies/active/0011.md) | *create* | *vote* | 0 | 0 | 0 | 0 | 8 | 16th of August 2021
+| [Policy 2](policies/active/0011.md) | *amend* | *passed* | 8 | 0 | 0 | 0 | 8 | 16th of August 2021
+| [Policy 11](policies/active/0011.md) | *create* | *passed* | 8 | 0 | 0 | 0 | 8 | 16th of August 2021

--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ The [definitions and clarifications](definitions.md) for terms used in these pol
 | [Policy 10](policies/active/0010.md) | *create* | *passed* | 8 | 0 | 0 | 0 | 8 | 11th of November 2020
 | [Policy 9](policies/active/0009.md) | *amend* | *passed* | 7 | 0 | 0 | 0 | 7 | 14th of April 2021
 | [Policy 10](policies/active/0010.md) | *amend* | *passed* | 7 | 0 | 0 | 0 | 7 | 14th of April 2021
-| [Policy 2](policies/active/0011.md) | *amend* | *passed* | 8 | 0 | 0 | 0 | 8 | 16th of August 2021
+| [Policy 2](policies/active/0002.md) | *amend* | *passed* | 8 | 0 | 0 | 0 | 8 | 16th of August 2021
 | [Policy 11](policies/active/0011.md) | *create* | *passed* | 8 | 0 | 0 | 0 | 8 | 16th of August 2021

--- a/policies/active/0002.md
+++ b/policies/active/0002.md
@@ -66,8 +66,19 @@ We will set some basic guidelines to follow which apply to all org members that 
 **Note**: Based on the rules, use your best judgement and if there's no one who can help you review at the time (and it can't wait) slap the QA bypassed label and merge it.
 
 ### <ins>Org forced removal</ins>
-- If there is a security concern, the user permissions should be restricted as soon as possible. QA and Core Dev leads should decide what the severity is and restrict the perms for this user.
-- If there is a concern for this user being part of the org, then at that point an org vote should be called between both the [Core Dev](https://github.com/orgs/Cog-Creators/teams/core-developers) and [QA](https://github.com/orgs/Cog-Creators/teams/quality-assurance) teams, and a decision on whether the member in question should be removed from the org should be made. 
+- If there is a security concern, the member's permissions should be **temporarily** restricted as soon as possible.
+  - Any member that has the ability to restrict the permissions can use this ability when they have reasonable concern that the security of organisation might be compromised by one of the members
+    - If the member restricting the permissions cannot restrict all the permissions that the member has, they should communicate with the members that do in order to fully restrict the permissions
+  - Permissions that should be restricted include, but might not be limited to:
+    - Teams that give **Triage** or higher permissions within some or all repositories in the GitHub organisation
+    - Individual rules on the GitHub repositories that give **Triage** or higher permissions
+    - Collaborator access to organisation's projects on PyPI
+    - Maintainer access to organisation's projects on Read the Docs
+    - Proofreader role and higher on organisation's projects on Crowdin
+    - Any sensitive roles in any of organisation's services (e.g. Cog Board)
+  - Once all of the member's permissions are restricted, it should be immediately disclosed to all active organisation members, including the member that had their permissions restricted
+  - The member(s) restricting permissions might be held accountable for it when they fail to provide the security concern their actions were based on
+- If there is a concern for this member being part of the org, then at that point an org vote should be called between both the [Core Dev](https://github.com/orgs/Cog-Creators/teams/core-developers) and [QA](https://github.com/orgs/Cog-Creators/teams/quality-assurance) teams, and a decision on whether the member in question should be removed from the org should be made. 
   - One or two members on each team should have team maintainer status in the event it is necessary to remove someone from their team when the Core Dev and QA leads are unavailable, to be decided by the team lead.
 
 **Note**: Certain titles have general expectations for the position. A core dev is expected to close issues by making pull requests and close issues that are no longer applicable; QA is expected to review open pull requests and close pull requests that are no longer valid. However, we recognize that everyone has their own strengths and preferences for the time they are volunteering to the project. Inactivity on the stated positional responsibilities and whether that translates to removal will be situational for each person. We are trusting the dev and QA teams to view each instance of this situation with consideration for the overall contributions of said person and whether they have been ignoring their duty to the project in general. However, it is strongly suggested that individuals spend some of their time on the positional expectations as a QA team and a dev team that continuously add new features will never get bug fixes, for example.

--- a/policies/active/0002.md
+++ b/policies/active/0002.md
@@ -77,7 +77,7 @@ We will set some basic guidelines to follow which apply to all org members that 
     - Proofreader role and higher on organisation's projects on Crowdin
     - Any sensitive roles in any of organisation's services (e.g. Cog Board)
   - Once all of the member's permissions are restricted, it should be immediately disclosed to all active organisation members, including the member that had their permissions restricted
-  - The member(s) restricting permissions might be held accountable for it when they fail to provide the security concern their actions were based on
+  - The organisation may choose to take action on an org member through policy 2 if the org member abuses this clause without a reasonable reason for concern
 - If there is a concern for this member being part of the org, then at that point an org vote should be called between both the [Core Dev](https://github.com/orgs/Cog-Creators/teams/core-developers) and [QA](https://github.com/orgs/Cog-Creators/teams/quality-assurance) teams, and a decision on whether the member in question should be removed from the org should be made. 
   - One or two members on each team should have team maintainer status in the event it is necessary to remove someone from their team when the Core Dev and QA leads are unavailable, to be decided by the team lead.
 


### PR DESCRIPTION
Summary of changes:
- **CHANGE:** Any member (instead of just QA and Core Dev leads) that has the ability to restrict the permissions can use it when they have a reasonable concern that the security of organization is compromised
- **NEW:** Such restriction should immediately be disclosed to all org members, including the affected member
- **NEW:** List various permissions that should be restricted when security concern arises